### PR TITLE
patch issue on autoDeployCheckFile()

### DIFF
--- a/src/Minifier.php
+++ b/src/Minifier.php
@@ -231,6 +231,10 @@ class Minifier
         $dir    = 'dir' . ucfirst(strtolower($fileType));
         $dirMin = 'dirMin' . ucfirst(strtolower($fileType));
 
+        if ($this->config->$dirMin === null) {
+            $dirMin = $dir
+        }
+        
         $assets   = [$filename => $this->config->$fileType[$filename]];
         $filePath = $this->config->$dirMin . '/' . $filename;
 
@@ -245,19 +249,14 @@ class Minifier
         $lastDeployTime = filemtime($filePath);
 
         // loop though the files and check last update time
-        $needDeploy = false;
         foreach ($assets[$filename] as $file)
         {
             $currentFileTime = filemtime($this->config->$dir . '/' . $file);
             if ($currentFileTime > $lastDeployTime)
             {
-                $needDeploy = true;
+                $this->deployFiles($fileType, $assets, $this->config->$dir, $this->config->$dirMin);
+                return true;
             }
-        }
-        if ($needDeploy) 
-        {
-            $this->deployFiles($fileType, $assets, $this->config->$dir, $this->config->$dirMin);
-            return true;
         }
         return false;
     }

--- a/src/Minifier.php
+++ b/src/Minifier.php
@@ -232,7 +232,7 @@ class Minifier
         $dirMin = 'dirMin' . ucfirst(strtolower($fileType));
 
         $assets   = [$filename => $this->config->$fileType[$filename]];
-        $filePath = $this->config->$dir . '/' . $filename;
+        $filePath = $this->config->$dirMin . '/' . $filename;
 
         // if file is not deployed
         if (! file_exists($filePath))

--- a/src/Minifier.php
+++ b/src/Minifier.php
@@ -232,7 +232,7 @@ class Minifier
         $dirMin = 'dirMin' . ucfirst(strtolower($fileType));
 
         if ($this->config->$dirMin === null) {
-            $dirMin = $dir
+            $dirMin = $dir;
         }
         
         $assets   = [$filename => $this->config->$fileType[$filename]];

--- a/src/Minifier.php
+++ b/src/Minifier.php
@@ -245,16 +245,20 @@ class Minifier
         $lastDeployTime = filemtime($filePath);
 
         // loop though the files and check last update time
+        $needDeploy = false;
         foreach ($assets[$filename] as $file)
         {
             $currentFileTime = filemtime($this->config->$dir . '/' . $file);
             if ($currentFileTime > $lastDeployTime)
             {
-                $this->deployFiles($fileType, $assets, $this->config->$dir, $this->config->$dirMin);
-                return true;
+                $needDeploy = true;
             }
         }
-
+        if ($needDeploy) 
+        {
+            $this->deployFiles($fileType, $assets, $this->config->$dir, $this->config->$dirMin);
+            return true;
+        }
         return false;
     }
 


### PR DESCRIPTION
 in autoDeployCheckFile() when $dirMin is used 
`/if (! file_exists($filePath))` use the bad directory

and optimisation on autoDeployCheckFile() for call deployFiles() only one time